### PR TITLE
Add styling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,4 +71,6 @@ group :test do
   gem "webdrivers"
 end
 
-gem 'sass-rails', '~> 6.0'
+gem "sassc-rails"
+gem 'better_errors'
+gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,13 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
+    better_errors (2.10.1)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
+      rouge (>= 1.0.0)
     bindex (0.8.1)
+    binding_of_caller (1.0.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -87,6 +93,7 @@ GEM
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    debug_inspector (1.1.0)
     erubi (1.12.0)
     ffi (1.15.5)
     globalid (1.1.0)
@@ -170,9 +177,8 @@ GEM
     reline (0.3.6)
       io-console (~> 0.5)
     rexml (3.2.5)
+    rouge (4.1.3)
     rubyzip (2.3.2)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -224,6 +230,8 @@ PLATFORMS
   x86_64-darwin-22
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   bootsnap
   capybara
   debug
@@ -233,7 +241,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.6)
   redis (~> 4.0)
-  sass-rails (~> 6.0)
+  sassc-rails
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,1 @@
+@import "config/fonts";

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,0 +1,12 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Yeseva+One&display=swap');
+
+$body-font: "Roboto", sans-serif;
+$headers-font: "Yeseva One", cursive, sans-serif;
+
+body {
+  font-family: $body-font;
+}
+
+h1 {
+  font-family: $headers-font;
+}

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,5 @@ module LearningtimeSem2ShDigitalNotebook
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-    config.assets.css_compressor = :sass
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,6 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.assets.debug = true
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,3 +10,4 @@ Rails.application.config.assets.version = "1.0"
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.paths << Rails.root.join("node_modules")


### PR DESCRIPTION
This PR adds enhance to the dev workflow by incorporating a Google Fonts and enabling debugging tools

**Changes:**
- Installs `better_errors` and `binding_of_caller` gems to help with debugging
- Imported Google Font styles 
- Enables `config.assets.debug = true` in the `config/environments/development.rb` file to serve CSS and JS files, without having to run `rails assets:precompile` when making a CSS change as it can become tedious

**Screenshots:**
<img width="557" alt="image" src="https://github.com/alphagov/learningtime-sem2-sh-digital-notebook/assets/56222256/bcc29fd5-440b-4b8f-ba3d-835b2e7cf8bf">
