### PR TITLE
Add basic Navbar Component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,5 @@
 @import "config/fonts";
+
+// Import all components:
+@import "components/index"
+

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -1,0 +1,1 @@
+@import "navbar";

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,0 +1,30 @@
+.navbar {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr;
+  align-items: center;
+  margin-top: 2rem;
+
+  &__logo {
+    text-align: center;
+    font-weight: bold;
+  }
+
+  &__links {
+    align-items: center;
+    gap: 20px;
+  }
+
+  &__links-left,
+  &__links-right {
+    display: flex;
+    justify-content: space-evenly;
+    align-items: center;
+  }
+
+  &__link {
+    text-decoration: none;
+    color: #333;
+  }
+
+}

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -1,3 +1,4 @@
+<%= render "shared/navbar" %>
 <section class="landing-section">
   <div class="main-picture">
   </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,0 +1,13 @@
+<nav class="navbar">
+  <div class="navbar__links-left">
+    <%= link_to "Home", "#", class: "navbar__link" %>
+    <%= link_to "Our Story", "#", class: "navbar__link"  %>
+    <%= link_to "Blog", "#", class: "navbar__link"  %>
+  </div>
+  <div class="navbar__logo">LearnedIt</div>
+  <div class="navbar__links-right">
+    <%= link_to "Contact", "#", class: "navbar__link"  %>
+    <%= link_to "Log In", "#", class: "navbar__link"  %>
+    <%= link_to "Sign Up", "#", class: "navbar__link"  %>
+  </div>
+</nav>


### PR DESCRIPTION
This PR adds the basic structure of a navbar without any styling or added logo

**Changes**:
- Created a navbar component to handle all navbar styling 
- Added the navbar in a shared folder so other pages can render the navbar partial 

**Screenshots**:
<img width="1497" alt="image" src="https://github.com/alphagov/learningtime-sem2-sh-digital-notebook/assets/56222256/49cc647b-5312-435d-b04f-76f4ab95157f">
