### PR TITLE
Setup cloudinary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+.env*

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem "bootsnap", require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem "dotenv-rails"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,5 @@ gem 'better_errors'
 gem 'binding_of_caller'
 
 gem "activesupport", ">= 7.0.7.1"
+
+gem "cloudinary"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
+    aws_cf_signer (0.1.3)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
@@ -87,6 +88,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cloudinary (1.27.0)
+      aws_cf_signer
+      rest-client (>= 2.0.0)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -94,6 +98,8 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     debug_inspector (1.1.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -102,6 +108,9 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.2.1)
@@ -124,6 +133,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.5.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0808)
     mini_mime (1.1.2)
     minitest (5.18.1)
     msgpack (1.7.2)
@@ -136,6 +148,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
@@ -180,6 +193,11 @@ GEM
     regexp_parser (2.8.1)
     reline (0.3.6)
       io-console (~> 0.5)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rouge (4.1.3)
     rubyzip (2.3.2)
@@ -213,6 +231,9 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -239,6 +260,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   capybara
+  cloudinary
   debug
   dotenv-rails
   importmap-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,10 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     debug_inspector (1.1.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     ffi (1.15.5)
     globalid (1.1.0)
@@ -236,6 +240,7 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  dotenv-rails
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -7,7 +7,11 @@
 
   &__logo {
     text-align: center;
-    font-weight: bold;
+  }
+
+  &__logo-text {
+    display: inline-block;
+    font-size: 1.8rem;
   }
 
   &__links {

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -4,7 +4,12 @@
     <%= link_to "Our Story", "#", class: "navbar__link"  %>
     <%= link_to "Blog", "#", class: "navbar__link"  %>
   </div>
-  <div class="navbar__logo">LearnedIt</div>
+  <div class="navbar__logo">
+    <%= cl_image_tag("https://res.cloudinary.com/dtjuz4kkr/image/upload/v1693485550/LearnedIt_logo_graphic_jghkns.png", height: 20) %>
+    <h1 class="navbar__logo-text">
+      LearnedIt
+    </h1>
+  </div>
   <div class="navbar__links-right">
     <%= link_to "Contact", "#", class: "navbar__link"  %>
     <%= link_to "Log In", "#", class: "navbar__link"  %>


### PR DESCRIPTION
This PR introduces the gem 'cloudinary' to host images/videos assets

**Changes**:
- Add `gem cloudinary` to the Gemfile
- Create a `.env` file 
- Add styling and adjust positioning of logo graphic and logo text

**Screenshots**:
<img width="268" alt="image" src="https://github.com/alphagov/learningtime-sem2-sh-digital-notebook/assets/56222256/4a09a060-5206-4e3e-b57f-5cc1dd425613">
